### PR TITLE
modernize template

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,1 @@
-{:lint-as {mount.core/defstate                  clojure.core/def
-
-           }}
+{:lint-as {mount.core/defstate                  clojure.core/def}}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target
 .shadow-cljs
 .clj-kondo/.cache
 .clj-kondo
+.portal

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ target
 .clj-kondo
 .portal
 .lsp
+.calva

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ target
 .clj-kondo/.cache
 .clj-kondo
 .portal
+.lsp

--- a/deps.edn
+++ b/deps.edn
@@ -14,13 +14,14 @@
 
            ;; Server
            mount/mount                            {:mvn/version "0.1.21"}
-           com.wsscode/pathom                     {:mvn/version "2.4.0"}
+           com.wsscode/pathom3                    {:mvn/version "2025.01.16-alpha"}
            hiccup/hiccup                          {:mvn/version "1.0.5"}
            ring/ring-defaults                     {:mvn/version "0.6.0"}
            ring/ring-core                         {:mvn/version "1.14.1"}
            http-kit/http-kit                      {:mvn/version "2.8.0"}
-           com.datomic/local                      {:mvn/version "1.0.291"}
            com.fulcrologic/fulcro-rad-datomic     {:mvn/version "1.5.6"}
+           com.datomic/local                      {:mvn/version "1.0.291"}
+           com.datomic/client-cloud               {:mvn/version "1.0.131"}
 
            ;; Unified logging for server
            com.taoensso/timbre                    {:mvn/version "6.6.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,47 +1,48 @@
 {:paths   ["src/main" "resources"]
 
- :deps    {org.clojure/clojure                    {:mvn/version "1.10.3"}
+ :deps    {org.clojure/clojure                    {:mvn/version "1.12.0"}
 
-           com.fulcrologic/fulcro                 {:mvn/version "3.5.28"}
-           com.fulcrologic/fulcro-rad             {:mvn/version "1.3.2"}
-           com.fulcrologic/fulcro-rad-semantic-ui {:mvn/version "1.2.15"}
-           com.fulcrologic/fulcro-i18n            {:mvn/version "0.0.5-alpha"}
+           com.fulcrologic/fulcro                 {:mvn/version "3.8.3"}
+           com.fulcrologic/fulcro-rad             {:mvn/version "1.6.12"}
+           com.fulcrologic/fulcro-rad-semantic-ui {:mvn/version "1.4.6"}
+           com.fulcrologic/fulcro-i18n            {:mvn/version "1.1.2"}
 
            ;; General extras
            cljc.java-time/cljc.java-time          {:mvn/version "0.1.18"}
-           edn-query-language/eql                 {:mvn/version "1.0.2"}
-           com.fulcrologic/guardrails             {:mvn/version "1.1.11"}
+           edn-query-language/eql                 {:mvn/version "2021.07.18"}
+           com.fulcrologic/guardrails             {:mvn/version "1.2.9"}
 
            ;; Server
-           mount/mount                            {:mvn/version "0.1.12"}
+           mount/mount                            {:mvn/version "0.1.21"}
            com.wsscode/pathom                     {:mvn/version "2.4.0"}
            hiccup/hiccup                          {:mvn/version "1.0.5"}
-           ring/ring-defaults                     {:mvn/version "0.3.4"}
-           ring/ring-core                         {:mvn/version "1.9.6"}
-           http-kit/http-kit                      {:mvn/version "2.6.0"}
-           com.datomic/local                      {:mvn/version "1.0.277"}
-           com.fulcrologic/fulcro-rad-datomic     {:mvn/version "1.3.2"}
+           ring/ring-defaults                     {:mvn/version "0.6.0"}
+           ring/ring-core                         {:mvn/version "1.14.1"}
+           http-kit/http-kit                      {:mvn/version "2.8.0"}
+           com.datomic/local                      {:mvn/version "1.0.291"}
+           com.fulcrologic/fulcro-rad-datomic     {:mvn/version "1.5.6"}
 
            ;; Unified logging for server
-           com.taoensso/timbre                    {:mvn/version "5.1.2"}
-           org.slf4j/log4j-over-slf4j             {:mvn/version "1.7.30"} ; auto sends log4j to slf4j
-           org.slf4j/jul-to-slf4j                 {:mvn/version "1.7.30"} ; auto sends java.util.logging to slf4j
-           org.slf4j/jcl-over-slf4j               {:mvn/version "1.7.30"} ; auto-sends java.common.logging to slf4j
-           com.fzakaria/slf4j-timbre              {:mvn/version "0.3.19"} ; hooks slf4j to timbre
+           com.taoensso/timbre                    {:mvn/version "6.6.1"}
+           org.slf4j/log4j-over-slf4j             {:mvn/version "2.0.17"} ; auto sends log4j to slf4j
+           org.slf4j/jul-to-slf4j                 {:mvn/version "2.0.17"} ; auto sends java.util.logging to slf4j
+           org.slf4j/jcl-over-slf4j               {:mvn/version "2.0.17"} ; auto-sends java.common.logging to slf4j
+           com.fzakaria/slf4j-timbre              {:mvn/version "0.4.1"} ; hooks slf4j to timbre
 
            }
 
  :aliases {:test      {:extra-paths ["src/test"]
                        :extra-deps  {fulcrologic/fulcro-spec {:mvn/version "3.1.12"}}}
 
-           :cljs      {:extra-deps {org.clojure/clojurescript                       {:mvn/version "1.10.879"}
-                                    thheller/shadow-cljs                            {:mvn/version "2.15.12"}
-                                    com.google.javascript/closure-compiler-unshaded {:mvn/version "v20210505"}
-                                    com.fulcrologic/semantic-ui-wrapper             {:mvn/version "2.0.1"}
-                                    binaryage/devtools                              {:mvn/version "1.0.4"}}}
+           :cljs      {:extra-deps {org.clojure/clojurescript                       {:mvn/version "1.11.132"}
+                                    thheller/shadow-cljs                            {:mvn/version "2.28.23"}
+                                    com.fasterxml.jackson.core/jackson-core         {:mvn/version "2.18.3"}
+                                    com.google.javascript/closure-compiler-unshaded {:mvn/version "v20240317"}
+                                    com.fulcrologic/semantic-ui-wrapper             {:mvn/version "2.1.4"}
+                                    binaryage/devtools                              {:mvn/version "1.0.7"}}}
 
            :run-tests {:main-opts  ["-m" "kaocha.runner"]
-                       :extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}}}
+                       :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
            :dev       {:extra-paths ["src/dev"]
-                       :extra-deps  {org.clojure/tools.namespace {:mvn/version "1.3.0"}}}}}
+                       :extra-deps  {org.clojure/tools.namespace {:mvn/version "1.5.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
            com.fulcrologic/fulcro-rad             {:mvn/version "1.6.12"}
            com.fulcrologic/fulcro-rad-semantic-ui {:mvn/version "1.4.6"}
            com.fulcrologic/fulcro-i18n            {:mvn/version "1.1.2"}
+           com.fulcrologic/fulcro-inspect         {:mvn/version "1.0.4"}
 
            ;; General extras
            cljc.java-time/cljc.java-time          {:mvn/version "0.1.18"}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "victory": "^36.2.0"
   },
   "devDependencies": {
-    "shadow-cljs": "2.15.12"
+    "shadow-cljs": "2.28.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "@js-joda/timezone": "^2.10.0",
     "big.js": "6.1.1",
     "intl-messageformat": "^9.9.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-toastify": "^11.0.5",
     "semantic-ui-react": "^2.0.4",
     "victory": "^36.2.0"
   },

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -18,8 +18,10 @@
                                      "@js-joda/timezone"
                                      {:target  :npm
                                       :require "@js-joda/timezone/dist/js-joda-timezone-10-year-range.min.js"}}}
-                       :devtools   {:preloads   [com.fulcrologic.fulcro.inspect.preload
-                                                 com.fulcrologic.fulcro.inspect.dom-picker-preload]
+                       :devtools   {:preloads   [com.fulcrologic.devtools.chrome-preload
+                                                 #_com.fulcrologic.devtools.electron-preload
+                                                 #_com.fulcrologic.fulcro.inspect.dom-picker-preload
+                                                 ]
                                     :after-load com.example.client/refresh}}
 
             :test     {:target           :browser-test

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:deps     {:aliases [:cljs :test]}
+{:deps     {:aliases [:cljs :dev :test]}
  :nrepl    {:port 9000}
  :jvm-opts ["-Xmx2G"]
  :builds   {:main     {:target     :browser

--- a/src/main/com/example/client.cljs
+++ b/src/main/com/example/client.cljs
@@ -3,6 +3,8 @@
     [com.example.application :refer [SPA]]
     [com.example.ui.root :refer [LandingPage Root]]
     [com.example.ui.toast :as toast]
+    [fulcro.inspect.tool :as it]
+    [com.fulcrologic.devtools.common.target :refer [ido]]
     [com.fulcrologic.fulcro.algorithms.timbre-support :refer [console-appender prefix-output-fn]]
     [com.fulcrologic.fulcro.application :as app]
     [com.fulcrologic.fulcro.components :as comp]
@@ -19,7 +21,8 @@
 
 (defn setup-RAD [app]
   (rad-app/install-ui-controls! app sui/all-controls)
-  (report/install-formatter! app :boolean :affirmation (fn [_ value] (if value "yes" "no"))))
+  (report/install-formatter! app :boolean :affirmation (fn [_ value] (if value "yes" "no")))
+  (ido (it/add-fulcro-inspect! app)))
 
 (defn wrap-error-reporting []
   (let [debounced-toast! (debounce toast/toast! 1000)]
@@ -35,7 +38,7 @@
                              js/fulcro_network_csrf_token)]
                  {:remotes
                   {:remote (net/fulcro-http-remote {:url "/api"
-                                                                ; add middleware and use `toast!` for errors
+                                                    ; add middleware and use `toast!` for errors
                                                     :response-middleware response-middleware
                                                     :request-middleware (rad-app/secured-request-middleware {:csrf-token token})})}})))
 

--- a/src/main/com/example/client.cljs
+++ b/src/main/com/example/client.cljs
@@ -6,10 +6,12 @@
     [fulcro.inspect.tool :as it]
     [com.fulcrologic.devtools.common.target :refer [ido]]
     [com.fulcrologic.fulcro.algorithms.timbre-support :refer [console-appender prefix-output-fn]]
+    [com.fulcrologic.fulcro.algorithms.tx-processing.batched-processing :as btxn]
     [com.fulcrologic.fulcro.application :as app]
     [com.fulcrologic.fulcro.components :as comp]
     [com.fulcrologic.fulcro.mutations :as m]
     [com.fulcrologic.fulcro.networking.http-remote :as net]
+    [com.fulcrologic.fulcro.react.version18 :refer [with-react18]]
     [com.fulcrologic.rad.application :as rad-app]
     [com.fulcrologic.rad.rendering.semantic-ui.semantic-ui-controls :as sui]
     [com.fulcrologic.rad.report :as report]
@@ -33,14 +35,16 @@
 
 (def response-middleware (-> (wrap-error-reporting) (net/wrap-fulcro-response)))
 
-(defonce app (rad-app/fulcro-rad-app
-               (let [token (when-not (undefined? js/fulcro_network_csrf_token)
-                             js/fulcro_network_csrf_token)]
-                 {:remotes
-                  {:remote (net/fulcro-http-remote {:url "/api"
+(defonce app (-> (rad-app/fulcro-rad-app
+                   (let [token (when-not (undefined? js/fulcro_network_csrf_token)
+                                 js/fulcro_network_csrf_token)]
+                     {:remotes
+                      {:remote (net/fulcro-http-remote {:url "/api"
                                                     ; add middleware and use `toast!` for errors
-                                                    :response-middleware response-middleware
-                                                    :request-middleware (rad-app/secured-request-middleware {:csrf-token token})})}})))
+                                                        :response-middleware response-middleware
+                                                        :request-middleware (rad-app/secured-request-middleware {:csrf-token token})})}}))
+                 (with-react18)
+                 (btxn/with-batched-reads)))
 
 (defn refresh []
   ;; hot code reload of installed controls

--- a/src/main/com/example/client.cljs
+++ b/src/main/com/example/client.cljs
@@ -2,23 +2,42 @@
   (:require
     [com.example.application :refer [SPA]]
     [com.example.ui.root :refer [LandingPage Root]]
+    [com.example.ui.toast :as toast]
     [com.fulcrologic.fulcro.algorithms.timbre-support :refer [console-appender prefix-output-fn]]
     [com.fulcrologic.fulcro.application :as app]
     [com.fulcrologic.fulcro.components :as comp]
     [com.fulcrologic.fulcro.mutations :as m]
+    [com.fulcrologic.fulcro.networking.http-remote :as net]
     [com.fulcrologic.rad.application :as rad-app]
     [com.fulcrologic.rad.rendering.semantic-ui.semantic-ui-controls :as sui]
     [com.fulcrologic.rad.report :as report]
     [com.fulcrologic.rad.routing.history :as history]
     [com.fulcrologic.rad.routing.html5-history :as hist5 :refer [html5-history]]
     [com.fulcrologic.rad.type-support.date-time :as datetime]
+    [goog.functions :refer [debounce]]
     [taoensso.timbre :as log]))
 
 (defn setup-RAD [app]
   (rad-app/install-ui-controls! app sui/all-controls)
   (report/install-formatter! app :boolean :affirmation (fn [_ value] (if value "yes" "no"))))
 
-(defonce app (reset! SPA (rad-app/fulcro-rad-app {})))
+(defn wrap-error-reporting []
+  (let [debounced-toast! (debounce toast/toast! 1000)]
+    (fn error-reporting [{:keys [body status-code error outgoing-request] :as response}]
+      (when (not= 200 status-code)
+            (debounced-toast! "There was an error.  Please try again."))
+      response)))
+
+(def response-middleware (-> (wrap-error-reporting) (net/wrap-fulcro-response)))
+
+(defonce app (rad-app/fulcro-rad-app
+               (let [token (when-not (undefined? js/fulcro_network_csrf_token)
+                             js/fulcro_network_csrf_token)]
+                 {:remotes
+                  {:remote (net/fulcro-http-remote {:url "/api"
+                                                                ; add middleware and use `toast!` for errors
+                                                    :response-middleware response-middleware
+                                                    :request-middleware (rad-app/secured-request-middleware {:csrf-token token})})}})))
 
 (defn refresh []
   ;; hot code reload of installed controls
@@ -36,6 +55,7 @@
   (log/merge-config! {:output-fn prefix-output-fn
                       :appenders {:console (console-appender)}})
   (log/info "Starting App")
+  (reset! SPA app)
   ;; default time zone (can be changed at login for given user)
   (history/install-route-history! app (html5-history))
   (datetime/set-timezone! "America/Los_Angeles")

--- a/src/main/com/example/components/parser.clj
+++ b/src/main/com/example/components/parser.clj
@@ -1,5 +1,8 @@
 (ns com.example.components.parser
   (:require
+    #_[com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
+    #_[com.wsscode.pathom.connect :as pc]
+    #_[com.wsscode.pathom.core :as p]
     [com.example.components.auto-resolvers :refer [automatic-resolvers]]
     [com.example.components.blob-store :as bs]
     [com.example.components.config :refer [config]]
@@ -7,51 +10,29 @@
     [com.example.components.delete-middleware :as delete]
     [com.example.components.save-middleware :as save]
     [com.example.model-rad.attributes :refer [all-attributes]]
-
     ;; Require namespaces that define resolvers
     [com.example.model.account :as m.account]
-
     [com.fulcrologic.rad.attributes :as attr]
     [com.fulcrologic.rad.blob :as blob]
-    [com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
+    [com.fulcrologic.rad.database-adapters.datomic-common :as common]
     [com.fulcrologic.rad.form :as form]
-    [com.fulcrologic.rad.pathom :as pathom]
-    [mount.core :refer [defstate]]
-    [com.wsscode.pathom.core :as p]
+    [com.fulcrologic.rad.pathom3 :as pathom3]
     [com.fulcrologic.rad.type-support.date-time :as dt]
-    [com.wsscode.pathom.connect :as pc]))
-
-(pc/defresolver index-explorer [{::pc/keys [indexes]} _]
-  {::pc/input  #{:com.wsscode.pathom.viz.index-explorer/id}
-   ::pc/output [:com.wsscode.pathom.viz.index-explorer/index]}
-  {:com.wsscode.pathom.viz.index-explorer/index
-   (p/transduce-maps
-     (remove (comp #{::pc/resolve ::pc/mutate} key))
-     indexes)})
+    [datomic.client.api :as d]
+    [mount.core :refer [defstate]]))
 
 (def all-resolvers
   "The list of all hand-written resolvers/mutations."
-  [index-explorer m.account/resolvers])
+  [#_index-explorer m.account/resolvers])
 
 (defstate parser
   :start
-  (pathom/new-parser config
-    [(attr/pathom-plugin all-attributes)                    ; Other plugins need the list of attributes. This adds it to env.
-     ;; Install form middleware
-     (form/pathom-plugin save/middleware delete/middleware)
-     ;; Select database for schema
-     (datomic/pathom-plugin (fn [env] {:production (:main datomic-connections)}))
-     ;; Enables binary object upload integration with RAD
-     (blob/pathom-plugin bs/temporary-blob-store {:files bs/file-blob-store})
-     {::p/wrap-parser
-      (fn transform-parser-out-plugin-external [parser]
-        (fn transform-parser-out-plugin-internal [env tx]
-          ;; Ensure the time zone is set for all resolvers/mutations
-          (dt/with-timezone "America/Los_Angeles"
-            (if (and (map? env) (seq tx))
-              (parser env tx)
-              {}))))}]
-    [automatic-resolvers
-     all-resolvers
-     form/resolvers
-     (blob/resolvers all-attributes)]))
+  (let [env-middleware (-> (attr/wrap-env all-attributes)
+                           (form/wrap-env save/middleware delete/middleware)
+                           (common/wrap-env (fn [env] {:production (:main datomic-connections)}) d/db)
+                           (blob/wrap-env bs/temporary-blob-store {:files bs/file-blob-store}))]
+    (pathom3/new-processor config env-middleware []
+      [automatic-resolvers
+       form/resolvers
+       (blob/resolvers all-attributes)
+       m.account/resolvers])))

--- a/src/main/com/example/components/parser.clj
+++ b/src/main/com/example/components/parser.clj
@@ -1,8 +1,5 @@
 (ns com.example.components.parser
   (:require
-    #_[com.fulcrologic.rad.database-adapters.datomic-cloud :as datomic]
-    #_[com.wsscode.pathom.connect :as pc]
-    #_[com.wsscode.pathom.core :as p]
     [com.example.components.auto-resolvers :refer [automatic-resolvers]]
     [com.example.components.blob-store :as bs]
     [com.example.components.config :refer [config]]
@@ -23,7 +20,7 @@
 
 (def all-resolvers
   "The list of all hand-written resolvers/mutations."
-  [#_index-explorer m.account/resolvers])
+  [m.account/resolvers])
 
 (defstate parser
   :start

--- a/src/main/com/example/model/account.cljc
+++ b/src/main/com/example/model/account.cljc
@@ -4,9 +4,10 @@
    DO NOT require a RAD model file in this ns. This ns is meant to be an ultimate
    leaf of the requires. Only include library code."
   (:require
-    [com.wsscode.pathom.connect :as pc :refer [defresolver defmutation]]
+    #_[com.wsscode.pathom.connect :as pc :refer [defresolver defmutation]]
     [com.fulcrologic.rad.database-adapters.datomic-options :as do]
     [com.fulcrologic.rad.ids :refer [new-uuid]]
+    [com.wsscode.pathom3.connect.operation :as pco]
     [datomic.client.api :as d]
     [taoensso.timbre :as log]))
 
@@ -37,8 +38,8 @@
        (log/error "No database atom for production schema!"))))
 
 #?(:clj
-   (defresolver all-accounts-resolver [env params]
-     {::pc/output [{:account/all-accounts [:account/id]}]}
+   (pco/defresolver all-accounts-resolver [env params]
+     {::pco/output [{:account/all-accounts [:account/id]}]}
      {:account/all-accounts (get-all-accounts env params)}))
 
 (def resolvers [all-accounts-resolver])

--- a/src/main/com/example/ui/root.cljc
+++ b/src/main/com/example/ui/root.cljc
@@ -1,12 +1,13 @@
 (ns com.example.ui.root
   "App UI root. Standard Fulcro."
   (:require
+    #?(:clj  [com.fulcrologic.fulcro.dom-server :as dom :refer [div label input]]
+       :cljs [com.fulcrologic.fulcro.dom :as dom :refer [div label input]])
     #?@(:cljs [[com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown :refer [ui-dropdown]]
                [com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-menu :refer [ui-dropdown-menu]]
                [com.fulcrologic.semantic-ui.modules.dropdown.ui-dropdown-item :refer [ui-dropdown-item]]])
-    #?(:clj  [com.fulcrologic.fulcro.dom-server :as dom :refer [div label input]]
-       :cljs [com.fulcrologic.fulcro.dom :as dom :refer [div label input]])
     [com.example.ui.account-forms :refer [AccountForm AccountList]]
+    [com.example.ui.toast :as toast]
     [com.fulcrologic.fulcro.application :as app]
     [com.fulcrologic.fulcro.components :as comp :refer [defsc]]
     [com.fulcrologic.fulcro.dom.html-entities :as ent]
@@ -32,7 +33,7 @@
   (dom/div
     (dom/div :.ui.loader {:classes [(when-not (= :routed current-state) "active")]})
     (when route-factory
-      (route-factory route-props))))
+          (route-factory route-props))))
 
 (def ui-main-router (comp/factory MainRouter))
 
@@ -46,19 +47,23 @@
   #?(:cljs
      (if ready?
        (let [busy? (seq active-remotes)]
-         (dom/div
-           (div :.ui.top.menu
-             (div :.ui.item "Demo")
-             (comp/fragment
-               (ui-dropdown {:className "item" :text "Account"}
-                 (ui-dropdown-menu {}
-                   (ui-dropdown-item {:onClick (fn [] (rroute/route-to! this AccountList {}))} "View All")
-                   (ui-dropdown-item {:onClick (fn [] (form/create! this AccountForm))} "New")))
-               (div :.ui.tiny.loader {:classes [(when busy? "active")]})))
-           (div :.ui.segment
-             (ui-main-router router))))
+         (comp/fragment
+           (toast/ui-toast-container)
+           (dom/div
+             (div :.ui.top.menu
+               (div :.ui.item "Demo")
+               (comp/fragment
+                 (ui-dropdown {:className "item" :text "Account"}
+                   (ui-dropdown-menu {}
+                     (ui-dropdown-item {:onClick (fn [] (rroute/route-to! this AccountList {}))} "View All")
+                     (ui-dropdown-item {:onClick (fn [] (form/create! this AccountForm))} "New")))
+                 (div :.ui.tiny.loader {:classes [(when busy? "active")]})))
+             (div :.ui.segment
+               (ui-main-router router)))))
        (div :.ui.active.dimmer
          (div :.ui.large.text.loader "Loading")))))
 
 (def ui-root (comp/factory Root))
 
+(comment
+  (toast/toast! "Testing"))

--- a/src/main/com/example/ui/root.cljc
+++ b/src/main/com/example/ui/root.cljc
@@ -45,10 +45,10 @@
    :initial-state {:ui/ready? false
                    :ui/router    {}}}
   #?(:cljs
-     (if ready?
-       (let [busy? (seq active-remotes)]
-         (comp/fragment
-           (toast/ui-toast-container)
+     (comp/fragment
+       (toast/ui-toast-container)
+       (if ready?
+         (let [busy? (seq active-remotes)]
            (dom/div
              (div :.ui.top.menu
                (div :.ui.item "Demo")
@@ -59,9 +59,9 @@
                      (ui-dropdown-item {:onClick (fn [] (form/create! this AccountForm))} "New")))
                  (div :.ui.tiny.loader {:classes [(when busy? "active")]})))
              (div :.ui.segment
-               (ui-main-router router)))))
-       (div :.ui.active.dimmer
-         (div :.ui.large.text.loader "Loading")))))
+               (ui-main-router router))))
+         (div :.ui.active.dimmer
+           (div :.ui.large.text.loader "Loading"))))))
 
 (def ui-root (comp/factory Root))
 

--- a/src/main/com/example/ui/toast.cljc
+++ b/src/main/com/example/ui/toast.cljc
@@ -1,0 +1,44 @@
+(ns com.example.ui.toast
+  #?(:cljs
+     (:require ["react-toastify" :refer [ToastContainer toast]]
+               [com.fulcrologic.fulcro.dom :as dom])))
+
+(defn ui-toast-container
+
+  "Embed the toast container. Must be placed somewhere near the root where it will always be rendered.
+   props are as described in https://fkhadra.github.io/react-toastify/introduction
+
+   * :position - one of top-right, top-left, top-center, bottom-*
+   * :autoClose - ms until closing (5000)
+   * :hideProgressBar - Default false
+   * :newestOnTop - Default false
+   * :closeOnClick - Default true
+   * :rtl - Default false
+   * :pauseOnFocusLoss - Default true
+   * :draggable - Default true
+   * :pauseOnHover - Default true
+
+   These can be overridden in the trigger function `toast!`.
+   "
+  ([props]
+   #?(:cljs (dom/create-element ToastContainer (clj->js props))))
+  ([]
+   #?(:cljs (dom/create-element ToastContainer))))
+
+(defn toast!
+  "Open a toast in the given toast container. Default options are specified on that container.
+   props can override the options (described at https://fkhadra.github.io/react-toastify/introduction)
+   * :position - one of top-right, top-left, top-center, bottom-*
+   * :autoClose - ms until closing
+   * :hideProgressBar
+   * :newestOnTop
+   * :closeOnClick
+   * :rtl
+   * :pauseOnFocusLoss
+   * :draggable
+   * :pauseOnHover
+  "
+  ([props message]
+   #?(:cljs (toast message (clj->js props))))
+  ([message]
+   #?(:cljs (toast message))))

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,19 +884,19 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shadow-cljs-jar@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
-  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
+shadow-cljs-jar@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz#0939d91c468b4bc5eab5a958f79e7ef5696fdf62"
+  integrity sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==
 
-shadow-cljs@2.15.12:
-  version "2.15.12"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.15.12.tgz#056ff707356538aefe8f5f07b7cb01e46758d10a"
-  integrity sha512-DKkQ9HIkQgV2yeWlwPUU02iw6Ucdw+Ks6r1XxESV/2I5V8ci4EJdZYcYiNS/GHYKDYaikJKSgmocxP+VtbYGJg==
+shadow-cljs@2.28.23:
+  version "2.28.23"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.28.23.tgz#06f2bc1f5345e35f8b0f995b4749ae4575654abe"
+  integrity sha512-SM7LeLctZLLCm6Y3NxWOH4GvHqHDZ6Jz9bUgfpJrk1jMADqIp3rliD6Rrd12gLX2b9/oEh6UyD7X+yw6O1++sw==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
-    shadow-cljs-jar "1.3.2"
+    shadow-cljs-jar "1.3.4"
     source-map-support "^0.4.15"
     which "^1.3.1"
     ws "^7.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,6 +273,11 @@ clsx@^1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
@@ -749,14 +754,13 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
@@ -781,13 +785,19 @@ react-popper@^2.3.0:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react-toastify@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.5.tgz#ce4c42d10eeb433988ab2264d3e445c4e9d13313"
+  integrity sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==
+  dependencies:
+    clsx "^2.1.1"
+
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.7"
@@ -844,13 +854,12 @@ safer-buffer@^2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 semantic-ui-react@^2.0.4:
   version "2.1.4"


### PR DESCRIPTION
Update most deps to latest.
Update to react18
Update to pathom3
Update to latest fulcro-inspect
Add react-toastify for notifications

This PR is an effort to modernize the template for my own use.  This is all from a dev branch in my fork of the fulcro-rad-template: https://github.com/michaelwhitford/fulcro-rad-template/tree/dev

I created each feature on a branch in my fork, just so I can cherry-pick commits in case you don't want everything included here.

The only outstanding task is the move from dynamic routing to statecharts.  I plan to do that work in a later PR.